### PR TITLE
Revert Bump danhunsaker/clover-reporter-action ...

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,7 +50,7 @@ jobs:
           overwrite: true
 
       - name: "Comment coverage report"
-        uses: danhunsaker/clover-reporter-action@v0.2.18
+        uses: danhunsaker/clover-reporter-action@v0.2.17-clover
         if: ${{ matrix.php-version == '8.4' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Revert "Bump danhunsaker/clover-reporter-action from 0.2.17.pre.clover to 0.2.18"

This reverts commit ad1ce47571ab122e747e507a9bc4046267f80577.

The new version doesn't seem to actually comment the coverage. Filed https://github.com/danhunsaker/clover-reporter-action/issues/6 about it.